### PR TITLE
Improve detail view show qty of materials

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -86,14 +86,53 @@
                   <div class="text-gray-600 hover:text-blue-600 text-sm underline cursor-pointer" @click="detailedView = !detailedView">Detailed view</div>
                 </div>
 
-                <div x-show="detailedView" class="text-sm text-center text-gray-800 mt-2">
-                  <div x-text="`Wood 🪵: ${(resources.wood * prices.wood).toFixed(2)} MOVR`"></div>
-                  <div x-text="`Stone 🪨: ${(resources.stone * prices.stone).toFixed(2)} MOVR`"></div>
-                  <div x-text="`Iron 🪙: ${(resources.iron * prices.iron).toFixed(2)} MOVR`"></div>
-                  <div x-text="`Exp 🟢: ${(resources.exp * prices.exp).toFixed(2)} MOVR`"></div>
-                  <div x-text="`Grain 🌾: ${(resources.grain * prices.grain).toFixed(2)} MOVR`"></div>
-                  <div x-text="`Gold 🥇: ${(resources.gold * prices.gold).toFixed(2)} MOVR`"></div>
-                </div>
+                <table x-show="detailedView" class="table-auto w-full text-sm text-left text-gray-800">
+                  <thead>
+                    <tr>
+                      <th colspan="2" >Material</th>
+                      <th>Quantity</th>
+                      <th>Price</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="w-1/12">🪵</td>
+                      <td class="w-3/12">Wood</td>
+                      <td class="w-3/12" x-text="`${parseFloat(resources.wood).toFixed(3)}`"></td>                  
+                      <td class="w-5/12" x-text="`${(resources.wood * prices.wood).toFixed(3)} MOVR`"></td>
+                    </tr>
+                    <tr>
+                      <td>🪨</td>
+                      <td>Stone</td>
+                      <td x-text="`${parseFloat(resources.stone).toFixed(3)}`"></td>                  
+                      <td x-text="`${(resources.stone * prices.stone).toFixed(3)} MOVR`"></td>
+                    </tr>
+                    <tr>
+                      <td>🪙</td>
+                      <td>Iron</td>
+                      <td x-text="`${parseFloat(resources.iron).toFixed(3)}`"></td>                  
+                      <td x-text="`${(resources.iron * prices.iron).toFixed(3)} MOVR`"></td>
+                    </tr>
+                    <tr>
+                      <td>🟢</td>
+                      <td>Exp</td>
+                      <td x-text="`${parseFloat(resources.exp).toFixed(3)}`"></td>                  
+                      <td x-text="`${(resources.exp * prices.exp).toFixed(3)} MOVR`"></td>
+                    </tr>
+                    <tr>
+                      <td>🌾</td>
+                      <td>Grain</td>
+                      <td x-text="`${parseFloat(resources.grain).toFixed(3)}`"></td>                  
+                      <td x-text="`${(resources.grain * prices.grain).toFixed(3)} MOVR`"></td>
+                    </tr>
+                    <tr>
+                      <td>🥇</td>
+                      <td>Gold</td>
+                      <td x-text="`${parseFloat(resources.gold).toFixed(3)}`"></td>                  
+                      <td x-text="`${(resources.gold * prices.gold).toFixed(3)} MOVR`"></td>
+                    </tr>                
+                  </tbody>
+                </table>
               </div>
 
             </div>


### PR DESCRIPTION
- Change input type to text and turn off autocorrect, etc
- Handle username input
- Add tabs
- Query resources on click
- Remove trailing spaces
- Style tabs and refactor HTML
- Display all resources upon fetch()
- Handle user not found
- Add navbar
- Get token prices in MOVR
- Query and display MOVR price
- Fix typo
- Expose getAllMaterialsMovr on window
- Delete trailing space
- Add spinning loader icon
- Adjust loader icon size
- Display USD value for each material
- Display total USD value
- Only show total USD and improve user not found
- Disable safari auto fill
- Prevent scroll to top on tab change
- Improve total resource value UI
- Disable tabs
- Add detailed resource view
- Replace # with / for main href
- Add Minecraft image
- Add footer
- Update README
- Remove extra padding x
- Show 2 decimals for MOVR total value
- Add comments
- Style navbar and add ingots icon
- Un-sticky navbar
- Add link to misterjame's Twitter
- Improve detail view show qty of materials
